### PR TITLE
Fixed error regarding `Provider`'s store.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,11 @@ import { reduxForm, reducer as formReducer } from 'redux-form';
 import { Provider } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 
+const reducers = { form: formReducer };
+const reducer = combineReducers(reducers);
+const store = createStore(reducer);
+
 const withReduxForm = (storyFunc) => {
-  const reducers = { form: formReducer };
-  const reducer = combineReducers(reducers);
-  const store = createStore(reducer);
   const Test = reduxForm({ form: 'withReduxForm' })(storyFunc);
   return (
     <Provider store={store}>


### PR DESCRIPTION
As the store was recreated on every call to `withReduxForm()`, the error `<Provider /> does not support changing store on the fly`, with a confusing explanation that turns out to be incorrect for our case.

Creating the store only once upon require time fixes the issue.