### PR TITLE
Allow react 16 as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "redux-form": "^7.4.2"
   },
   "dependencies": {
-    "react": "^15.5.4",
+    "react": "^15.5.4 || ^16.0.0",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "redux-form": "^7.4.2",


### PR DESCRIPTION
Thanks for the library, working great for us - using react 16.13.1 currently.